### PR TITLE
Initial ForwardsBackward implementation

### DIFF
--- a/src/main/java/com/allenai/ml/math/SloppyMath.java
+++ b/src/main/java/com/allenai/ml/math/SloppyMath.java
@@ -1,0 +1,23 @@
+package com.allenai.ml.math;
+
+import java.util.stream.DoubleStream;
+
+public class SloppyMath {
+
+    private final static double EXP_THRESH = -30.0;
+
+    /**
+     * @return log(sum_i exp(vals_i))
+     */
+    public static double logSumExp(double[] vals) {
+        double max = DoubleStream.of(vals).max().orElse(Double.NEGATIVE_INFINITY);
+        double sumNegativeDifferences = DoubleStream.of(vals)
+                .map(x -> x - max)
+                .filter(x -> x > EXP_THRESH)
+                .map(Math::exp)
+                .sum();
+        return sumNegativeDifferences > 0.0
+                ? max + Math.log(sumNegativeDifferences)
+                : max;
+    }
+}

--- a/src/main/java/com/allenai/ml/sequences/ForwardBackwards.java
+++ b/src/main/java/com/allenai/ml/sequences/ForwardBackwards.java
@@ -1,0 +1,118 @@
+package com.allenai.ml.sequences;
+
+import com.allenai.ml.math.SloppyMath;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.*;
+import java.util.function.ToDoubleFunction;
+import java.util.stream.DoubleStream;
+
+/**
+ * Efficient implementation of the ForwardBackwards algorithm
+ */
+public class ForwardBackwards<S> {
+    private final StateSpace<S> stateSpace;
+    private final int numStates;
+    private final int numTransitions;
+
+    public ForwardBackwards(StateSpace<S> stateSpace) {
+        this.stateSpace = stateSpace;
+        this.numStates = stateSpace.states().size();
+        this.numTransitions = stateSpace.transitions().size();
+    }
+
+    /**
+     *
+     * @param logPotentials 2d array of the scores associated with the state-space transition for each sequence position.
+     *                      Specifically there are [seqLen-1][numStateSpaceTransitions] values, where
+     *                      logPotentials[i][t] represents the log-space score for using the `t`th indexed transition
+     *                      in the underlying `StateSpace` and `i` represents the `i`th transition.
+     * @return Result object that lazily yields ForwardBackwards quantities. 
+     */
+    public Result compute(double[][] logPotentials) {
+        return new Result(logPotentials);
+    }
+
+    /**
+     * A class that lazily computes various quantities associated with the ForwardBackwards algorithms. You only
+     * pay for the things you actually consume (e.g. if you only need the viterbi decoding, you don't do the backward
+     * pass).
+     */
+    public class Result {
+        private final double[][] potentials;
+        private final int seqLen;
+
+        private Result(double[][] potentials) {
+            this.potentials = potentials;
+            this.seqLen = potentials.length+1;
+        }
+
+        @Getter(lazy = true)
+        private final List<S> viterbi = computeViterbi();
+
+        @Getter(value = AccessLevel.PRIVATE, lazy = true)
+        private final double[][] alpahs = computeAlphas(SloppyMath::logSumExp);
+
+        public double getLogZ() {
+            return getAlpahs()[seqLen-1][stateSpace.stopStateIndex()];
+        }
+
+        private double[][] computeAlphas(ToDoubleFunction<double[]> combiner) {
+            double[][] alphas = new double[seqLen][numStates];
+            for (double[] row: alphas) {
+                Arrays.fill(row, Double.NEGATIVE_INFINITY);
+            }
+            // initialize
+            alphas[0][stateSpace.startStateIndex()] = 0.0;
+            // go forwards
+            for (int i=1; i < seqLen; ++i) {
+                int prevPos = i-1;
+                for (int s=0; s < numStates; ++s) {
+                    double[] forwardPaths = stateSpace.transitionsTo(s)
+                        .stream()
+                        .mapToDouble(t -> alphas[prevPos][t.fromState] + potentials[prevPos][t.selfIndex])
+                        .toArray();
+                    alphas[i][s] = combiner.applyAsDouble(forwardPaths);
+                }
+            }
+            return alphas;
+        }
+
+        private List<S> computeViterbi() {
+            // Use the MAX operation to compute alphas
+            double[][] maxAlphas = computeAlphas(xs -> DoubleStream.of(xs).max().orElse(Double.NEGATIVE_INFINITY));
+            // Compute the best path iteratively by figuring out which operation lead to it rather
+            // than compute and store back-pointers, this is more efficient since a memory read is much
+            // cheaper than a write
+            double targetValue =  maxAlphas[seqLen-1][stateSpace.stopStateIndex()];
+            int targetState = stateSpace.stopStateIndex();
+            List<S> result = new ArrayList<>();
+            for (int pos=seqLen-2; pos >= 0; --pos) {
+                // Need these next two variables to be effectively final
+                int curPos = pos;
+                double curTarget = targetValue;
+                // Find the transition that leads to the target value
+                Optional<Transition> correctTransition = stateSpace.transitionsTo(targetState)
+                        .stream()
+                        .filter(trans -> {
+                            double value = potentials[curPos][trans.selfIndex] + maxAlphas[curPos][trans.fromState];
+                            return Math.abs(value - curTarget) < 1.0e-8;
+                        })
+                        .findFirst();
+                if (!correctTransition.isPresent()) {
+                    throw new RuntimeException("viterbi can't find path found by computeAlphas(MAX)");
+                }
+                targetState = correctTransition.get().fromState;
+                targetValue = maxAlphas[pos][targetState];
+                // Add state to result as long as not start state
+                if (pos > 0) {
+                    result.add(stateSpace.states().get(targetState));
+                }
+            }
+            // We've built answer backwards
+            Collections.reverse(result);
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/allenai/ml/sequences/StateSpace.java
+++ b/src/main/java/com/allenai/ml/sequences/StateSpace.java
@@ -1,0 +1,146 @@
+package com.allenai.ml.sequences;
+
+import com.gs.collections.api.list.MutableList;
+import com.gs.collections.api.map.primitive.MutableIntObjectMap;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.list.mutable.FastList;
+import com.gs.collections.impl.map.mutable.primitive.IntObjectHashMap;
+import com.gs.collections.impl.tuple.Tuples;
+import lombok.val;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * A container object for various aspects of the state space. This object is only meant to be built via factory methods.
+ */
+public class StateSpace<S> {
+    private final List<S> states;
+    private final List<Transition> transitions;
+    private final MutableIntObjectMap<MutableList<Transition>> fromTransitions;
+    private final MutableIntObjectMap<MutableList<Transition>> toTransitions;
+
+    /**
+     * Package private constructor.
+     * @param states It's assumed that states[0] and states[1] are the start/stop states.
+     * @param transitionPairs All allowed transitions, including those starting/ending from start/stop respectively
+     */
+    StateSpace(List<S> states, Set<Pair<S, S>> transitionPairs) {
+        Map<S, Integer> stateIndex = IntStream.range(0, states.size())
+                .boxed()
+                .collect(Collectors.toMap(states::get, Function.identity()));
+        this.states = new ArrayList<>(states);
+        this.transitions = new ArrayList<>();
+        for (Pair<S, S> transitionPair : transitionPairs) {
+            int startIndex = stateIndex.get(transitionPair.getOne());
+            int stopIndex = stateIndex.get(transitionPair.getTwo());
+            int transitionIndex = transitions.size();
+            transitions.add(Transition.of(startIndex, stopIndex, transitionIndex));
+        }
+        this.fromTransitions = new IntObjectHashMap<>(this.states.size());
+        this.toTransitions = new IntObjectHashMap<>(this.states.size());
+        for (Transition trans : transitions) {
+            fromTransitions
+                .getIfAbsentPut(trans.fromState, FastList::new)
+                .add(trans);
+            toTransitions
+                .getIfAbsentPut(trans.toState, FastList::new)
+                .add(trans);
+
+        }
+    }
+
+    public Optional<Transition> transitionFor(S from, S to) {
+        int fromIndex = states.indexOf(from);
+        int toIndex = states.indexOf(to);
+        if (fromIndex < 0 || toIndex < 0) {
+            return Optional.empty();
+        }
+        return transitionFrom(fromIndex).stream()
+            .filter(t -> t.toState == toIndex)
+            .findFirst();
+    }
+
+    public List<Transition> transitionFrom(int stateIndex) {
+        return Collections.unmodifiableList(fromTransitions.getIfAbsent(stateIndex, FastList::new));
+    }
+
+    public List<Transition> transitionsTo(int stateIndex) {
+        return Collections.unmodifiableList(toTransitions.getIfAbsent(stateIndex, FastList::new));
+    }
+
+    public Pair<S, S> transition(int transitionIndex) {
+        val t = transitions.get(transitionIndex);
+        return Tuples.pair(states.get(t.fromState), states.get(t.toState));
+    }
+
+    public S startState() {
+        return states.get(0);
+    }
+
+    public S stopState() {
+        return states.get(1);
+    }
+
+    /**
+     * __NOTE__: This isn't a performant method and is intended only for debugging
+     * @return Index of the underlying state or -1 if not there.
+     */
+    public int stateIndex(S state) {
+        return states.indexOf(state);
+    }
+
+    public List<S> states() {
+        return Collections.unmodifiableList(states);
+    }
+
+    public List<Transition> transitions() {
+        return Collections.unmodifiableList(transitions);
+    }
+
+    public int startStateIndex() {
+        return 0;
+    }
+
+    public int stopStateIndex() {
+        return 1;
+    }
+
+    private static <S> List<S> ensureStartStopPadded(List<S> seq, S start, S stop) {
+        // defensive copy
+        seq = new ArrayList<>(seq);
+        if (seq.size() == 0 || !seq.get(0).equals(start)) {
+            seq.add(0, start);
+        }
+        int lastIndex = seq.size()-1;
+        if (seq.size() < 2 || !seq.get(lastIndex).equals(stop)) {
+            seq.add(stop);
+        }
+        return seq;
+    }
+
+    private static <S> List<Pair<S,S>> transitions(List<S> seq) {
+        List<Pair<S, S>> pairs = new ArrayList<>(seq.size()-1);
+        for (int idx=0; idx < seq.size()-1; ++idx) {
+            pairs.add(Tuples.pair(seq.get(idx), seq.get(idx+1)));
+        }
+        return pairs;
+    }
+
+    public static <S> StateSpace<S> buildFromSequences(Collection<List<S>> sequences, S startState, S stopState) {
+        List<S> states = new ArrayList<>();
+        states.addAll(Arrays.asList(startState, stopState));
+        Set<S> nonStartStopStates = sequences.stream()
+                .flatMap(Collection::stream)
+                .filter(s -> !s.equals(startState) && !s.equals(stopState))
+                .collect(Collectors.toSet());
+        states.addAll(nonStartStopStates);
+        Set<Pair<S, S>> transitionPairs = sequences.stream()
+                .map(seq -> ensureStartStopPadded(seq, startState, stopState))
+                .flatMap(seq -> transitions(seq).stream())
+                .collect(Collectors.toSet());
+        return new StateSpace<>(states, transitionPairs);
+    }
+}

--- a/src/main/java/com/allenai/ml/sequences/Transition.java
+++ b/src/main/java/com/allenai/ml/sequences/Transition.java
@@ -1,0 +1,19 @@
+package com.allenai.ml.sequences;
+
+import lombok.Data;
+import lombok.Value;
+
+
+/**
+ * A transition represents `(from, to)` transition between states. We store the `selfIndex` of the from and to state
+ * as well as its index relative to other transitions. This is meant to only be used internal to this package.
+ *
+ *  __Note__: Default access-level is intentional
+ * @See StateSpace
+ */
+@Data(staticConstructor = "of")
+class Transition {
+    public final int fromState;
+    public final int toState;
+    public final int selfIndex;
+}

--- a/src/test/java/com/allenai/ml/math/SloppyMathTest.java
+++ b/src/test/java/com/allenai/ml/math/SloppyMathTest.java
@@ -1,0 +1,27 @@
+package com.allenai.ml.math;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+import java.util.stream.DoubleStream;
+
+@Test
+public class SloppyMathTest {
+    public void testLogSumExp() throws Exception {
+        Random rand = new Random(0L);
+        int MIN = -100;
+        int MAX = 100;
+        int N = 100;
+        int numRandCases = 100;
+        for (int idx=0; idx < numRandCases; ++idx) {
+            double[] vals = DoubleStream
+                .generate(() -> rand.nextInt(MAX-MIN) + MIN)
+                .limit(N)
+                .toArray();
+            double fast = SloppyMath.logSumExp(vals);
+            double slow = Math.log(DoubleStream.of(vals).map(Math::exp).sum());
+            assertEquals(fast, slow, 1.0e-10);
+        }
+   }
+}

--- a/src/test/java/com/allenai/ml/sequences/ForwardBackwardsTest.java
+++ b/src/test/java/com/allenai/ml/sequences/ForwardBackwardsTest.java
@@ -1,0 +1,62 @@
+package com.allenai.ml.sequences;
+
+import com.gs.collections.impl.factory.Lists;
+import com.gs.collections.impl.factory.Sets;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static com.gs.collections.impl.tuple.Tuples.pair;
+import static org.testng.Assert.*;
+
+@Test
+public class ForwardBackwardsTest {
+
+    // toy NP segmentation problem
+    String START = "<s>";
+    String STOP = "</s>";
+    String BEGIN = "BEGIN";
+    String MIDDLE = "MIDDLE";
+    String OUTSIDE = "OUTSIDE";
+
+    StateSpace<String> segmentationStateSpace = new StateSpace<>(
+            Lists.mutable.of(START, STOP, BEGIN, MIDDLE, OUTSIDE),
+            Sets.mutable.of(pair(START, BEGIN),
+                    pair(START, OUTSIDE),
+                    pair(BEGIN, MIDDLE),
+                    pair(BEGIN, OUTSIDE),
+                    pair(MIDDLE, MIDDLE),
+                    pair(MIDDLE, BEGIN),
+                    pair(MIDDLE, OUTSIDE),
+                    pair(MIDDLE, STOP),
+                    pair(OUTSIDE, OUTSIDE),
+                    pair(OUTSIDE, BEGIN),
+                    pair(OUTSIDE, STOP)));
+
+    public void testSegmentation() throws Exception {
+        // Example sentence
+        // <s> the_B dog_M hit_O the_B ball_M </s>
+        // for this example, BEGIN is the start of a chunk
+        // and START is reserved for the start of the entire sequence
+        int seqLen = 7;
+        double[][] potentials = new double[seqLen-1][segmentationStateSpace.transitions().size()];
+        for (double[] row : potentials) {
+            Arrays.fill(row, Double.NEGATIVE_INFINITY);
+        }
+        int startToBeginIdx = segmentationStateSpace.transitionFor(START, BEGIN).get().selfIndex;
+        int beginToMiddleIdx = segmentationStateSpace.transitionFor(BEGIN, MIDDLE).get().selfIndex;
+        int middleToOutsideIdx = segmentationStateSpace.transitionFor(MIDDLE, OUTSIDE).get().selfIndex;
+        int outsideToBeginIdx = segmentationStateSpace.transitionFor(OUTSIDE, BEGIN).get().selfIndex;
+        int middleToStopIdx = segmentationStateSpace.transitionFor(MIDDLE, STOP).get().selfIndex;
+        potentials[0][startToBeginIdx] = 0.0;
+        potentials[1][beginToMiddleIdx] = 0.0;
+        potentials[2][middleToOutsideIdx] = 0.0;
+        potentials[3][outsideToBeginIdx] = 0.0;
+        potentials[4][beginToMiddleIdx] = 0.0;
+        potentials[5][middleToStopIdx] = 0.0;
+        ForwardBackwards<String> fb = new ForwardBackwards<>(segmentationStateSpace);
+        ForwardBackwards<String>.Result result = fb.compute(potentials);
+        assertEquals(result.getViterbi(), Arrays.asList(BEGIN, MIDDLE, OUTSIDE, BEGIN, MIDDLE));
+        assertEquals(result.getLogZ(), 0.0);
+    }
+}

--- a/src/test/java/com/allenai/ml/sequences/StateSpaceTest.java
+++ b/src/test/java/com/allenai/ml/sequences/StateSpaceTest.java
@@ -1,0 +1,47 @@
+package com.allenai.ml.sequences;
+
+import com.gs.collections.impl.factory.Lists;
+import com.gs.collections.impl.factory.Sets;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+@Test
+public class StateSpaceTest {
+    @Test
+    public void testBuildFromSequences() throws Exception {
+        String START = "<s>";
+        String STOP = "</s>";
+        String S1 = "s1";
+        String S2 = "s2";
+        String S3 = "s3";
+        // S1 -> S3
+        // S1 -> S2 -> S3
+        StateSpace<String> stateSpace = StateSpace.buildFromSequences(
+                Lists.fixedSize.of(Lists.fixedSize.of(S1, S2), Lists.fixedSize.of(S1, S2, S3)),
+                START, STOP);
+        // Test States
+        assertEquals(stateSpace.startState(), START);
+        assertEquals(stateSpace.stopState(), STOP);
+        assertEquals(new HashSet<>(stateSpace.states()), new HashSet<>(Lists.fixedSize.of(START, STOP, S1, S2, S3)));
+        // Test Transitions
+        Set<String> fromStartStates = stateSpace.transitionFrom(stateSpace.stateIndex(START)).stream()
+                .map(t -> stateSpace.transition(t.selfIndex).getTwo())
+                .collect(Collectors.toSet());
+        assertEquals(fromStartStates, Sets.immutable.of(S1));
+        Set<String> s1Transitions = stateSpace.transitionFrom(stateSpace.stateIndex(S1))
+                .stream()
+                .map(t -> stateSpace.transition(t.selfIndex).getTwo())
+                .collect(Collectors.toSet());
+        assertEquals(s1Transitions, Sets.mutable.of(S2));
+        Set<String> toStopTransitions = stateSpace.transitionsTo(stateSpace.stateIndex(STOP))
+                .stream()
+                .map(t -> stateSpace.transition(t.selfIndex).getOne())
+                .collect(Collectors.toSet());
+        assertEquals(toStopTransitions, Sets.mutable.of(S2, S3));
+    }
+}


### PR DESCRIPTION
Initial implementation of the ForwardsBackwards algorithm. Meant to be performant with a few isolated areas that can be refactored pending profile. Best entry point is to look at `ForwardBackwardsTest` and the associated source code. The `README` should be sufficient to get started with the project. 

Some specifics
- This is only doing viterbi decoding and `logZ` for sequences since that's all that's needed for inference
- Future PR will add an adapter for building the state-space and potential filler for the CRF++ or any other external system used to train CRF models. 
- There's a trick that's used for decoding whereby you do a faster version of the forward (alpha) pass rather than store back-pointers as you build the DP table. This is generally faster since a main memory write is much slower than a read (and that gap is actually increasing as you get more cores with their own caches). 

possible reviewers: @cristipp, @jakemannix, @vha14
