### PR TITLE
Numerical optimization and Batch dataset objective

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // TestNG for testing
     testCompile 'org.testng:testng:6.8.1'
 
-    // Benchmarking
+    // Benchmarking - dependencies don't go into production jars
     jmh 'commons-io:commons-io:2.4'
 
     // To use Markdown instead of Javadoc HTML

--- a/src/main/java/com/allenai/ml/objective/BatchObjectiveFn.java
+++ b/src/main/java/com/allenai/ml/objective/BatchObjectiveFn.java
@@ -1,0 +1,84 @@
+package com.allenai.ml.objective;
+
+import com.allenai.ml.linalg.DenseVector;
+import com.allenai.ml.linalg.Vector;
+import com.allenai.ml.optimize.GradientFn;
+import lombok.SneakyThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+/**
+ * Objective function calculation over an entire dataset. Natively supports multiple threads of execution. You can
+ * wrap this function with a regularization `GradientFn` if desired.
+ */
+public class BatchObjectiveFn<T> implements GradientFn {
+    private final List<T> data;
+    private final long dimension;
+    private final ExampleObjectiveFn<T> exampleObjectiveFn;
+    private final int numThreads = Runtime.getRuntime().availableProcessors();
+    private final ExecutorService executorService;
+
+    private class Worker implements Runnable {
+        List<T> subList;
+        double objectiveValue = 0.0;
+        Vector objectiveGradient = DenseVector.of(dimension);
+        Vector weights ;
+
+        Worker(List<T> subList, Vector weights) {
+            this.subList = subList;
+            this.weights = weights;
+        }
+
+        @Override
+        public void run() {
+            for (T t : subList) {
+                objectiveValue += exampleObjectiveFn.evaluate(t, weights, objectiveGradient);
+            }
+        }
+    }
+
+    public BatchObjectiveFn(List<T> data, ExampleObjectiveFn<T> exampleObjectiveFn, long dimension, int numThreads) {
+        // copy to a GS collection
+        this.data = new ArrayList<>(data);
+        this.exampleObjectiveFn = exampleObjectiveFn;
+        this.dimension = dimension;
+        this.executorService = Executors.newFixedThreadPool(numThreads);
+    }
+
+    @Override
+    @SneakyThrows({InterruptedException.class, ExecutionException.class})
+    public Result apply(Vector weights) {
+        // defensive copy so all workers can read this instance
+        weights = weights.copy();
+        List<Worker> workers = new ArrayList<>();
+        int chunkSize = data.size() / numThreads;
+        for (int idx = 0; idx < numThreads; idx++) {
+            int start = idx * chunkSize;
+            int stop = idx + 1 < numThreads ? (idx+1) * chunkSize : data.size();
+            workers.add(new Worker(data.subList(start, stop), weights));
+        }
+        List<Future<?>> futureStream = workers.stream()
+            .map(executorService::submit)
+            .collect(Collectors.toList());
+        for (Future<?> f : futureStream) {
+            f.get();
+        }
+        double objectiveValue = workers.stream().mapToDouble(w -> w.objectiveValue).sum();
+        Vector objectiveGradient = DenseVector.of(dimension);
+        workers.stream()
+            .map(w -> w.objectiveGradient)
+            .forEach(g -> objectiveGradient.addInPlace(1.0, g));
+        return Result.of(objectiveValue, objectiveGradient);
+    }
+
+    @Override
+    public long dimension() {
+        return dimension;
+    }
+}

--- a/src/main/java/com/allenai/ml/objective/ExampleObjectiveFn.java
+++ b/src/main/java/com/allenai/ml/objective/ExampleObjectiveFn.java
@@ -1,0 +1,19 @@
+package com.allenai.ml.objective;
+
+import com.allenai.ml.linalg.Vector;
+
+/**
+ * Interface for updating a single example. Meant to be used with a `BatchObjectiveFn` to setup the
+ * optimization function for a machine learning problem.
+ */
+public interface ExampleObjectiveFn<T> {
+    /**
+     *
+     * @param example The example to operate on
+     * @param inParams read-only version of the current paramters
+     * @param outGrad Meant to be mutated by the function to reflect the gradient updates from this example
+     * @return The objective function value for this example.
+     */
+    double evaluate(T example, Vector inParams, Vector outGrad);
+
+}

--- a/src/main/java/com/allenai/ml/optimize/BacktrackingLineMinimizer.java
+++ b/src/main/java/com/allenai/ml/optimize/BacktrackingLineMinimizer.java
@@ -1,0 +1,31 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.Vector;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@RequiredArgsConstructor(staticName = "of")
+public class BacktrackingLineMinimizer implements LineMinimizer {
+    final double alpha, beta, minStepLen;
+
+    @Override
+    public Result minimize(GradientFn gradFn, Vector x, Vector dir) {
+        val valGradPair = gradFn.apply(x);
+        double f0 = valGradPair.fx;
+        val grad = valGradPair.grad;
+        if (grad.l2NormSquared() < minStepLen) {
+            return Result.of(0.0, f0);
+        }
+        final double delta = beta * grad.dotProduct(dir);
+        double stepLen = 1.0;
+        while (stepLen >= minStepLen) {
+            Vector stepX = x.add(stepLen, dir);
+            final double fx = gradFn.apply(stepX).fx;
+            if (fx <= f0 + stepLen * delta) {
+                return Result.of(stepLen, fx);
+            }
+            stepLen *= alpha;
+        }
+        throw new RuntimeException("Step-size underflow: can't make the value smaller along gradient");
+    }
+}

--- a/src/main/java/com/allenai/ml/optimize/CachingGradientFn.java
+++ b/src/main/java/com/allenai/ml/optimize/CachingGradientFn.java
@@ -1,0 +1,45 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.Vector;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.val;
+
+import java.util.LinkedList;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CachingGradientFn implements GradientFn {
+    private final int maxHistory;
+    private final GradientFn gradFn;
+    private final LinkedList<HistoryEntry> history = new LinkedList<>();
+
+    @RequiredArgsConstructor
+    public class HistoryEntry {
+        final Vector input;
+        final double output;
+        final Vector grad;
+    }
+
+    @Override
+    public GradientFn.Result apply(Vector x) {
+        Optional<HistoryEntry> foundEntry = this.history
+            .stream()
+            .filter(e -> e.input.closeTo(x))
+            .findFirst();
+        if (foundEntry.isPresent()) {
+            return GradientFn.Result.of(foundEntry.get().output, foundEntry.get().grad);
+        }
+        val result = this.gradFn.apply(x);
+        val entry = new HistoryEntry(x, result.fx, result.grad);
+        this.history.addFirst(entry);
+        if (this.history.size() > this.maxHistory) {
+            this.history.removeLast();
+        }
+        return result;
+    }
+    @Override
+    public long dimension() {
+        return gradFn.dimension();
+    }
+}

--- a/src/main/java/com/allenai/ml/optimize/GradientFn.java
+++ b/src/main/java/com/allenai/ml/optimize/GradientFn.java
@@ -1,0 +1,42 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.Vector;
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Function;
+
+/**
+ * Abstraction for a function from a real-valued Vector to a pair of `[f(x), grad f(x)]`. This is the type
+ * of function which can be easily minimized via numerical optimization
+ */
+public interface GradientFn extends Function<Vector, GradientFn.Result> {
+
+    @RequiredArgsConstructor(staticName = "of")
+    class Result {
+        public final double fx;
+        public final Vector grad;
+    }
+
+    @Override
+    Result apply(Vector vec);
+
+    long dimension();
+
+    static GradientFn from(long dimension, Function<Vector, Result> fn) {
+        return new GradientFn() {
+            @Override
+            public Result apply(Vector vec) {
+                if (vec.dimension() != this.dimension()) {
+                    throw new IllegalArgumentException("Argument doesn't match dimesnion(): " +
+                        vec.dimension() + " != " + this.dimension());
+                }
+                return fn.apply(vec);
+            }
+
+            @Override
+            public long dimension() {
+                return dimension;
+            }
+        };
+    }
+}

--- a/src/main/java/com/allenai/ml/optimize/GradientFnMinimizer.java
+++ b/src/main/java/com/allenai/ml/optimize/GradientFnMinimizer.java
@@ -1,0 +1,39 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.DenseVector;
+import com.allenai.ml.linalg.Vector;
+import lombok.RequiredArgsConstructor;
+
+@FunctionalInterface
+/**
+ * Core interface to be used by users of this package.
+ */
+public interface GradientFnMinimizer {
+
+    /**
+     * Result struct for the output of minimization
+     */
+    @RequiredArgsConstructor(staticName = "of")
+    class Result {
+        /**
+         * The minimal value of f(xmin)
+         */
+        public final double fxmin;
+        /**
+         * The argument vector yielding the minimum value
+         */
+        public final Vector xmin;
+    }
+
+    default Result minimize(GradientFn gradFn) {
+        return this.minimize(gradFn, DenseVector.of(gradFn.dimension()));
+    }
+
+    /**
+     * Key interface function
+     * @param gradFn Function to be minimized
+     * @param initGuess Initial guess. For a non-approximate minimizer, this only affects convergence speed.
+     * @return
+     */
+    Result minimize(GradientFn gradFn, Vector initGuess);
+}

--- a/src/main/java/com/allenai/ml/optimize/LineMinimizer.java
+++ b/src/main/java/com/allenai/ml/optimize/LineMinimizer.java
@@ -1,0 +1,24 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.Vector;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Interface for solving problems of the form `min_alpha f(x + stepLength * dir)` for a direction `dir`
+ */
+@FunctionalInterface
+public interface LineMinimizer {
+    @RequiredArgsConstructor(staticName = "of")
+    class Result {
+        /**
+         * The distance along `dir` which yields the minimal value
+         */
+        public final double stepLength;
+        /**
+         * The function value at `gradFn( x.add(stepLength, dir) )`
+         */
+        public final double fxmin;
+    }
+
+    Result minimize(GradientFn gradFn, Vector x, Vector dir);
+}

--- a/src/main/java/com/allenai/ml/optimize/NewtonMethod.java
+++ b/src/main/java/com/allenai/ml/optimize/NewtonMethod.java
@@ -1,0 +1,80 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.Vector;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.util.function.Function;
+
+/**
+ * Family of gradient minimizer based on Newton's method. Each iteration of the algorithm takes a current
+ * minimum guess and then based on that guess, a next step direction is chosen using the `QuasiNewton` approximation.
+ * We perform a line-minimization along that direction for our new guess. Depending on the `QuasiNewton`, you get different
+ * algorithms.
+ */
+@Slf4j(topic = "NewtonMethodOptimize")
+public class NewtonMethod implements GradientFnMinimizer {
+
+    private final Function<GradientFn, QuasiNewton> quasiNewtonFn;
+    private final Opts opts;
+
+    public static class Opts {
+        int maxIters = 150;
+        double tolerance = 1.0e-10;
+        double alpha = 0.5;
+        double beta = 0.01;
+        double stepLenTolerance = 1.0e-10;
+
+        public LineMinimizer lineMinimizer() {
+            return BacktrackingLineMinimizer.of(alpha, beta, stepLenTolerance);
+        }
+    }
+
+    public NewtonMethod(Function<GradientFn, QuasiNewton> quasiNewtonFn) {
+        this(quasiNewtonFn, new Opts());
+    }
+
+    public NewtonMethod(Function<GradientFn, QuasiNewton> quasiNewtonFn, Opts opts) {
+        this.quasiNewtonFn = quasiNewtonFn;
+        this.opts = opts;
+    }
+
+    private Vector step(GradientFn gradFn, Vector x, LineMinimizer ls, QuasiNewton qn) {
+        Vector grad = gradFn.apply(x).grad;
+        Vector dir = qn.implictMultiply(grad);
+        dir.scaleInPlace(-1.0);
+        val lsRes = ls.minimize(gradFn, x, dir);
+        return x.add(lsRes.stepLength, dir);
+    }
+
+    private final static double EPS = 1.0e-200;
+
+    @Override
+    public Result minimize(GradientFn gradFn, Vector initGuess) {
+        QuasiNewton qn = this.quasiNewtonFn.apply(gradFn);
+        val lm = this.opts.lineMinimizer();
+        Vector x = initGuess;
+        for (int i=0; i < opts.maxIters; ++i) {
+            // iteration
+            val curRes = gradFn.apply(x);
+            val xnew = step(gradFn, x, lm, qn);
+            val newRes = gradFn.apply(xnew);
+            if (newRes.fx > curRes.fx) {
+                throw new IllegalStateException("Step increased function value");
+            }
+            double larger = Math.min(Math.abs(curRes.fx), Math.abs(newRes.fx));
+            double relDiff = Math.abs(newRes.fx-curRes.fx)/ Math.max(larger, EPS);
+            log.info("[Iteration {}] Ended with value {} and relDiff {}\n", i, newRes.fx, relDiff);
+            if (relDiff < opts.tolerance) {
+                break;
+            }
+            // update
+            qn.update(xnew.add(-1.0,x), newRes.grad.add(-1.0, curRes.grad));
+            x = xnew;
+        }
+        return Result.of(gradFn.apply(x).fx, x);
+    }
+}

--- a/src/main/java/com/allenai/ml/optimize/QuasiNewton.java
+++ b/src/main/java/com/allenai/ml/optimize/QuasiNewton.java
@@ -1,0 +1,102 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.Vector;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.tuple.Tuples;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interface for how to approximate `H^{-1} dir`, where `H^{-1}` is an approximation for the inverse hessian and
+ * dir is the current search direction. If we use `H^{-1}` as the identity matrix, you get standard gradient descent.
+ * If you remember some history, you get LBFGS.
+ */
+@FunctionalInterface
+public interface QuasiNewton {
+
+    /**
+     * @return Approximation of inverse hessian matrix times `dir`
+     */
+    Vector implictMultiply(Vector dir);
+
+    /**
+     * Update the approximation
+     * @param xDelta The delta from the last guess
+     * @param gradDelta The delta from the function gradient at last guess
+     */
+    default void update(Vector xDelta, Vector gradDelta) {
+        // intentional no-op
+    }
+
+    /**
+     * Approximate inverse hessian with the identity
+     */
+    static QuasiNewton gradientDescent() {
+        return dir -> dir;
+    }
+
+    /**
+     * LBFGS inverse hessian approximation
+     */
+    static QuasiNewton lbfgs(final int maxHistorySize) {
+        return new QuasiNewton() {
+            // Store (xDelta, gradDelta) pairs
+            private final List<Pair<Vector, Vector>> history = new ArrayList<>();
+
+            private double initialScale() {
+                if (history.isEmpty()) {
+                    return 1.0;
+                }
+                Vector lastInputDiff = history.get(0).getOne();
+                Vector lastGradDiff = history.get(0).getTwo();
+                double numer = lastGradDiff.dotProduct(lastInputDiff);
+                double denom = lastGradDiff.l2NormSquared();
+                assert denom > 0.0 : "Shouldn't have gotten a 0 diff between successive gradients";
+                return numer / denom;
+            }
+
+            @Override
+            public Vector implictMultiply(Vector dir) {
+                double[] rho = new double[history.size()];
+                double[] alpha = new double[history.size()];
+                Vector right = dir.copy();
+                for (int i = history.size() - 1; i >= 0; i--) {
+                    Vector inputDifference = history.get(i).getOne();
+                    Vector derivativeDifference = history.get(i).getTwo();
+                    rho[i] = inputDifference.dotProduct(derivativeDifference);
+                    assert rho[i]!= 0.0 : "Input diff and derivative diff can't be orthogonal by construction";
+                    alpha[i] = inputDifference.dotProduct(right) / rho[i];
+                    right = right.add(-alpha[i], derivativeDifference);
+                }
+                right.scaleInPlace(initialScale());
+                Vector left = right;
+                for (int i = 0; i < history.size(); i++) {
+                    Vector inputDifference = history.get(i).getOne();
+                    Vector derivativeDifference = history.get(i).getTwo();
+                    double beta = derivativeDifference.dotProduct(left) / rho[i];
+                    left = left.add(alpha[i] - beta, inputDifference);
+                }
+                return left;
+            }
+
+
+            private final static double EPS = 1.0e-200;
+
+            @Override
+            public void update(Vector xDelta, Vector gradDelta) {
+                if (xDelta.l2NormSquared() < EPS || gradDelta.l2NormSquared() < EPS) {
+                    throw new IllegalArgumentException("Too small a diff between successive input or gradient." +
+                        "Should have already converged already");
+                }
+                if (gradDelta.l2NormSquared() < EPS) {
+                    throw new IllegalArgumentException("Can't have this small input delta: " + gradDelta.l2NormSquared());
+                }
+                this.history.add(0, Tuples.pair(xDelta, gradDelta));
+                while (this.history.size() > maxHistorySize) {
+                    this.history.remove(this.history.size()-1);
+                }
+              }
+        };
+    }
+}

--- a/src/main/java/com/allenai/ml/sequences/StateSpace.java
+++ b/src/main/java/com/allenai/ml/sequences/StateSpace.java
@@ -37,7 +37,7 @@ public class StateSpace<S> {
             int startIndex = stateIndex.get(transitionPair.getOne());
             int stopIndex = stateIndex.get(transitionPair.getTwo());
             int transitionIndex = transitions.size();
-            transitions.add(Transition.of(startIndex, stopIndex, transitionIndex));
+            transitions.add(new Transition(startIndex, stopIndex, transitionIndex));
         }
         this.fromTransitions = new IntObjectHashMap<>(this.states.size());
         this.toTransitions = new IntObjectHashMap<>(this.states.size());

--- a/src/main/java/com/allenai/ml/sequences/Transition.java
+++ b/src/main/java/com/allenai/ml/sequences/Transition.java
@@ -1,5 +1,6 @@
 package com.allenai.ml.sequences;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Value;
 
@@ -11,7 +12,7 @@ import lombok.Value;
  *  __Note__: Default access-level is intentional
  * @See StateSpace
  */
-@Data(staticConstructor = "of")
+@AllArgsConstructor
 class Transition {
     public final int fromState;
     public final int toState;

--- a/src/test/java/com/allenai/ml/linalg/SparseVectorTest.java
+++ b/src/test/java/com/allenai/ml/linalg/SparseVectorTest.java
@@ -1,5 +1,7 @@
 package com.allenai.ml.linalg;
 
+import com.gs.collections.impl.map.mutable.primitive.LongDoubleHashMap;
+import lombok.val;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -13,6 +15,15 @@ public class SparseVectorTest {
         sparse.set(0, 1.0);
         sparse.set(1, 2.0);
         assertEquals(sparse.dotProduct(dense), 5.0);
+    }
+
+    public void testCreateFactoryMethods() {
+        val v1 = SparseVector.withCapacity(10, 100);
+        v1.set(0, 1.0);
+        VectorTest.testCopy(v1);
+        val v2 = SparseVector.make(new LongDoubleHashMap(10), 100);
+        v2.set(0, 1.0);
+        VectorTest.testCopy(v2);
     }
 
     public void testCopy() throws Exception {

--- a/src/test/java/com/allenai/ml/objective/BatchObjectiveFnTest.java
+++ b/src/test/java/com/allenai/ml/objective/BatchObjectiveFnTest.java
@@ -1,0 +1,48 @@
+package com.allenai.ml.objective;
+
+import com.allenai.ml.linalg.DenseVector;
+import com.allenai.ml.linalg.Vector;
+import com.allenai.ml.optimize.GradientFn;
+import com.allenai.ml.optimize.GradientFnMinimizer;
+import com.allenai.ml.optimize.NewtonMethod;
+import com.allenai.ml.optimize.QuasiNewton;
+import lombok.AllArgsConstructor;
+import lombok.val;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+@Test
+public class BatchObjectiveFnTest {
+
+    @AllArgsConstructor
+    class RegressionExample {
+        double target;
+        Vector featVec;
+    }
+
+
+    public void testLinearRegression() {
+        List<RegressionExample> examples = Arrays.asList(
+            new RegressionExample(1.0, DenseVector.of(0.5, 0.5)),
+            new RegressionExample(2.0, DenseVector.of(1.0, 1.0)),
+            new RegressionExample(3.0, DenseVector.of(1.5, 1.5)));
+        ExampleObjectiveFn<RegressionExample> regressionObjective = (example, weights, grad) -> {
+            double guess = example.featVec.dotProduct(weights);
+            double diff = guess - example.target;
+            grad.addInPlace(diff, example.featVec);
+            return 0.5 * diff * diff;
+        };
+        GradientFn objFn = new BatchObjectiveFn<>(examples, regressionObjective, 2, 2);
+        val res = objFn.apply(DenseVector.of(2));
+        assertEquals(res.fx, 0.5 * (1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0), 1.0e-4);
+
+        val minimizer = new NewtonMethod(__ -> QuasiNewton.lbfgs(3));
+        val minResult = minimizer.minimize(objFn);
+        assertEquals(minResult.fxmin, 0.0, 1.0e-4);
+        assertTrue(minResult.xmin.closeTo(DenseVector.of(1.0, 1.0)));
+    }
+}

--- a/src/test/java/com/allenai/ml/optimize/BacktrackingLineMinimizerTest.java
+++ b/src/test/java/com/allenai/ml/optimize/BacktrackingLineMinimizerTest.java
@@ -1,0 +1,20 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.DenseVector;
+import lombok.val;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertEquals;
+
+@Test
+public class BacktrackingLineMinimizerTest {
+    public void testBacktrackingLineSearcher() throws Exception {
+        val ls = BacktrackingLineMinimizer.of(0.5, 0.01, 1.0e-10);
+        LineMinimizer.Result result = ls.minimize(TestUtils.xSquared.fn, DenseVector.of(1.0), DenseVector.of(-1.0));
+        assertEquals(result.stepLength, 1.0,0.001);
+        assertEquals(result.fxmin, 0.0, 0.001);
+        LineMinimizer.Result result2 = ls.minimize(TestUtils.xSquared.fn, DenseVector.of(0.0), DenseVector.of(1.0));
+        assertEquals(result2.stepLength,0.0, 0.001);
+        assertEquals(result2.fxmin,0.0, 0.001);
+    }
+}

--- a/src/test/java/com/allenai/ml/optimize/CachingGradientFnTest.java
+++ b/src/test/java/com/allenai/ml/optimize/CachingGradientFnTest.java
@@ -1,0 +1,43 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.DenseVector;
+import com.allenai.ml.linalg.Vector;
+import lombok.val;
+import org.testng.annotations.Test;
+
+import java.util.function.Function;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test
+public class CachingGradientFnTest {
+    class CountingFn<T,R> implements Function<T,R> {
+        private int callCount = 0;
+        private final Function<T,R> fn;
+        CountingFn(Function<T, R> fn) {
+      this.fn = fn;
+    }
+        @Override
+        public R apply(T t) {
+            callCount++;
+            return fn.apply(t);
+        }
+    }
+
+    @Test
+    public void testCachingGradientFn() throws Exception {
+        CountingFn<Vector, GradientFn.Result> countXSquared = new CountingFn<>(TestUtils.xSquared.fn);
+        val cacheGradFn = new CachingGradientFn(1, GradientFn.from(1, countXSquared));
+        // Underlying fn should only be called once
+        cacheGradFn.apply(DenseVector.of(1.0));
+        assertEquals(countXSquared.callCount, 1);
+        cacheGradFn.apply(DenseVector.of(1.0));
+        assertEquals("Result should be cached",countXSquared.callCount, 1);
+        // Replace cache should trigger fresh call
+        cacheGradFn.apply(DenseVector.of(2.0));
+        cacheGradFn.apply(DenseVector.of(1.0));
+        assertEquals("Cache should be cleared",countXSquared.callCount, 3);
+        cacheGradFn.apply(DenseVector.of(1.0));
+        assertEquals("Result should be cached",countXSquared.callCount, 3);
+  }
+}

--- a/src/test/java/com/allenai/ml/optimize/NewtonMethodTest.java
+++ b/src/test/java/com/allenai/ml/optimize/NewtonMethodTest.java
@@ -1,0 +1,34 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.DenseVector;
+import lombok.val;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class NewtonMethodTest {
+
+    @Test
+    public void testGradientDescent() throws Exception {
+        val minimizer = new NewtonMethod(__ -> QuasiNewton.gradientDescent());
+        testMinimizer(minimizer);
+    }
+
+    @Test
+    public void testLBFGS() throws Exception {
+        testMinimizer(new NewtonMethod(__ -> QuasiNewton.lbfgs(1)));
+        testMinimizer(new NewtonMethod(__ -> QuasiNewton.lbfgs(3)));
+    }
+
+    public void testMinimizer(GradientFnMinimizer minimizer) {
+        testExample(minimizer, TestUtils.quartic);
+        testExample(minimizer, TestUtils.xSquared);
+    }
+
+    public void testExample(GradientFnMinimizer minimizer, TestUtils.MinExample example) {
+        val res = minimizer.minimize(example.fn, DenseVector.of(example.fn.dimension()));
+        assertTrue(res.xmin.closeTo(example.argMin, 0.1));
+        assertEquals(res.fxmin, example.min, 0.001);
+    }
+}

--- a/src/test/java/com/allenai/ml/optimize/TestUtils.java
+++ b/src/test/java/com/allenai/ml/optimize/TestUtils.java
@@ -1,0 +1,34 @@
+package com.allenai.ml.optimize;
+
+import com.allenai.ml.linalg.DenseVector;
+import com.allenai.ml.linalg.Vector;
+import lombok.RequiredArgsConstructor;
+
+public class TestUtils {
+
+    @RequiredArgsConstructor
+    public static class MinExample {
+        public final GradientFn fn;
+        public final Vector argMin;
+        public final double min;
+    }
+
+    // f(x) = x^2
+    public static final MinExample xSquared = new MinExample(
+        GradientFn.from(1, x -> GradientFn.Result.of(
+            x.at(0) * x.at(0),
+            DenseVector.of(2.0 * x.at(0)))),
+        DenseVector.of(0.0),
+        0.0);
+
+    // f(x,y) = (x-1)^4 + (y + 2.0)^4
+    // minimum at (1,-2) with value 0.0
+    public static final MinExample quartic = new MinExample(
+        GradientFn.from(2, x -> {
+            double val = Math.pow(x.at(0) - 1.0, 4.0) + Math.pow(x.at(1) + 2.0, 4.0);
+            Vector grad = DenseVector.of(4 * Math.pow(x.at(0) - 1.0, 3.0), 4 * Math.pow(x.at(1) + 2.0, 3.0));
+            return GradientFn.Result.of(val, grad);
+        }),
+        DenseVector.of(1.0, -2.0),
+        0.0);
+}


### PR DESCRIPTION
There are two key things in this PR

* Standard numerical optimization interfaces and a Newton's method implementation. I could've used another implementation, but from experience with non-convex applications, I know I'm going to want control over how the history is handled. 
* A batch objective function abstraction I've used in the past. The best entry-point is the test `BatchObjectiveFnTest` which shows how you optimize simple linear regression. The interface here is pretty simple and you get per-machine parallelism. You can have a `SparkBatchObjectiveFn` which still utilizes the same `ExampleObjectiveFn` interface, but until that's needed not bothering.

After this PR, I'll submit one which trains a CRF model using these modules; the only work is CRF-specific objective value and gradient (the logZ from forward-backwards as well as the node/edge marginals). 