### PR TITLE
Added support for marginals to forwards-backward and CRF weight encoding

### DIFF
--- a/src/main/java/com/allenai/ml/linalg/SparseVector.java
+++ b/src/main/java/com/allenai/ml/linalg/SparseVector.java
@@ -1,5 +1,7 @@
 package com.allenai.ml.linalg;
 
+import com.gs.collections.api.LazyLongIterable;
+import com.gs.collections.api.iterator.LongIterator;
 import com.gs.collections.api.map.primitive.LongDoubleMap;
 import com.gs.collections.api.map.primitive.MutableLongDoubleMap;
 import com.gs.collections.api.tuple.primitive.LongDoublePair;
@@ -11,70 +13,70 @@ import java.util.stream.Stream;
 
 public class SparseVector implements Vector {
 
-  private final MutableLongDoubleMap vec;
-  private final long dimension;
+    private final MutableLongDoubleMap vec;
+    private final long dimension;
 
-  private SparseVector(MutableLongDoubleMap vec, long dimension) {
+    private SparseVector(MutableLongDoubleMap vec, long dimension) {
       this.vec = vec;
       this.dimension = dimension;
-  }
+    }
 
-  public static SparseVector withCapacity(int capacity, long dimension) {
+    public static SparseVector withCapacity(int capacity, long dimension) {
       return new SparseVector(new LongDoubleHashMap(capacity), dimension);
-  }
+    }
 
-  public static SparseVector fromEntries(Stream<Entry> entries, long dimension) {
+    public static SparseVector fromEntries(Stream<Entry> entries, long dimension) {
       val vec = new LongDoubleHashMap();
       entries.forEach(e -> vec.put(e.index, e.value));
       return new SparseVector(vec, dimension);
-  }
+    }
 
-  public static SparseVector make(long dimension) {
+    public static SparseVector make(long dimension) {
       return new SparseVector(new LongDoubleHashMap(), dimension);
-  }
+    }
 
-  public static SparseVector make(LongDoubleMap vec, long dimension) {
+    public static SparseVector make(LongDoubleMap vec, long dimension) {
       return new SparseVector(new LongDoubleHashMap(vec), dimension);
-  }
+    }
 
-  public static SparseVector make() {
+    public static SparseVector make() {
       return make(Long.MAX_VALUE);
-  }
+    }
 
-  @Override
-  public long dimension() {
+    @Override
+    public long dimension() {
       return dimension;
-  }
+    }
 
-  @Override
-  public double at(long dimensionIdx) {
+    @Override
+    public double at(long dimensionIdx) {
       return vec.get(dimensionIdx);
-  }
+    }
 
-  @Override
-  public void set(long dimensionIdx, double val) {
+    @Override
+    public void set(long dimensionIdx, double val) {
       vec.put(dimensionIdx, val);
-  }
+    }
 
-  @Override
-  public long numStoredEntries() {
+    @Override
+    public long numStoredEntries() {
       return vec.size();
-  }
+    }
 
-  @Override
-  public Vector copy() {
+    @Override
+    public Vector copy() {
       return new SparseVector(new LongDoubleHashMap(vec), dimension);
-  }
+    }
 
-  @Override
-  public Stream<Entry> nonZeroEntries() {
+    @Override
+    public Stream<Entry> nonZeroEntries() {
       long[] indices = vec.keySet().toArray();
       return LongStream.of(indices)
           .mapToObj(idx -> Vector.Entry.of(idx, vec.get(idx)));
-  }
+    }
 
-  @Override
-  public double dotProduct(Vector other) {
+    @Override
+    public double dotProduct(Vector other) {
       if (other.numStoredEntries() < this.numStoredEntries()) {
           return other.dotProduct(this);
       }
@@ -87,5 +89,5 @@ public class SparseVector implements Vector {
           result += val * other.at(idx);
       }
       return result;
-  }
+    }
 }

--- a/src/main/java/com/allenai/ml/linalg/Vector.java
+++ b/src/main/java/com/allenai/ml/linalg/Vector.java
@@ -5,6 +5,7 @@ import lombok.val;
 
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -164,6 +165,12 @@ public interface Vector {
         return result;
     }
 
+    default double add(long idx, double val) {
+        double newVal = at(idx) + val;
+        set(idx, newVal);
+        return newVal;
+    }
+
     default void addInPlace(double scale, Vector dir) {
         dir.nonZeroEntries().forEach((Entry e) ->
             this.inc(e.getIndex(), scale * e.getValue()));
@@ -175,6 +182,91 @@ public interface Vector {
 
     default void scaleInPlace(double v) {
         this.nonZeroEntries().forEach(e -> this.set(e.getIndex(), v * e.getValue()));
+    }
+
+    /**
+     * For use cases when you don't want to allocate `Vector.Entry` on a per-entry basis and want to re-use the iterator
+     * without object allocation. This interface allows for an implementation where there is no object allocation
+     * associated with iterating over elements or re-using.
+     * Example usage:
+     * ```java
+     * while (it.isExhausted()) {
+     *     long idx = it.index();
+     *     double val = it.value();
+     *     // do stuff with (idx, val)
+     *     it.advance();
+     * }
+     * it.reset(); // can now safely re-use
+     * ```
+     */
+    interface Iterator {
+        boolean isExhausted();
+        void reset();
+        void advance();
+        long index();
+        double value();
+    }
+
+    /**
+     * Add an iterator's entries to the receiver, returning self
+     * @param scale
+     * @param iter
+     * @return `this` for chaining
+     */
+    default Vector addInPlace(double scale, Vector.Iterator iter) {
+        while (!iter.isExhausted()) {
+            long idx = iter.index();
+            this.set(idx, this.at(idx) + scale * iter.value());
+            iter.advance();
+        }
+        return this;
+    }
+
+    default Vector addInPlace(Vector.Iterator iter) {
+        return addInPlace(1.0, iter);
+    }
+
+    /**
+     * External iterator, useful for when you don't want object allocation
+     * to access individual elements (an internal iterator would require
+     * creating a pair object for the index/value).
+     */
+    default Iterator iterator() {
+        val entries = nonZeroEntries().collect(Collectors.toList());
+        return new Iterator() {
+            int idx = 0;
+            @Override
+            public boolean isExhausted() {
+                return idx >= entries.size();
+            }
+
+            public void advance() {
+                idx += 1;
+            }
+
+            private void ensureNotExhausted(String message) {
+                if (isExhausted()) {
+                    throw new RuntimeException(message);
+                }
+            }
+
+            @Override
+            public long index() {
+                ensureNotExhausted("Iterator is exhausted");
+                return entries.get(idx).index;
+            }
+
+            @Override
+            public double value() {
+                ensureNotExhausted("Must call advance() before index()");
+                return entries.get(idx).value;
+            }
+
+            @Override
+            public void reset() {
+                idx = 0;
+            }
+        };
     }
 
     @Data(staticConstructor = "of")

--- a/src/main/java/com/allenai/ml/optimize/NewtonMethod.java
+++ b/src/main/java/com/allenai/ml/optimize/NewtonMethod.java
@@ -60,7 +60,7 @@ public class NewtonMethod implements GradientFnMinimizer {
         for (int i=0; i < opts.maxIters; ++i) {
             // iteration
             val curRes = gradFn.apply(x);
-            val xnew = step(gradFn, x, lm, qn);
+            Vector xnew = step(gradFn, x, lm, qn);
             val newRes = gradFn.apply(xnew);
             if (newRes.fx > curRes.fx) {
                 throw new IllegalStateException("Step increased function value");

--- a/src/main/java/com/allenai/ml/optimize/QuasiNewton.java
+++ b/src/main/java/com/allenai/ml/optimize/QuasiNewton.java
@@ -89,9 +89,6 @@ public interface QuasiNewton {
                     throw new IllegalArgumentException("Too small a diff between successive input or gradient." +
                         "Should have already converged already");
                 }
-                if (gradDelta.l2NormSquared() < EPS) {
-                    throw new IllegalArgumentException("Can't have this small input delta: " + gradDelta.l2NormSquared());
-                }
                 this.history.add(0, Tuples.pair(xDelta, gradDelta));
                 while (this.history.size() > maxHistorySize) {
                     this.history.remove(this.history.size()-1);

--- a/src/main/java/com/allenai/ml/sequences/StateSpace.java
+++ b/src/main/java/com/allenai/ml/sequences/StateSpace.java
@@ -27,7 +27,7 @@ public class StateSpace<S> {
      * @param states It's assumed that states[0] and states[1] are the start/stop states.
      * @param transitionPairs All allowed transitions, including those starting/ending from start/stop respectively
      */
-    StateSpace(List<S> states, Set<Pair<S, S>> transitionPairs) {
+    public StateSpace(List<S> states, Set<Pair<S, S>> transitionPairs) {
         Map<S, Integer> stateIndex = IntStream.range(0, states.size())
                 .boxed()
                 .collect(Collectors.toMap(states::get, Function.identity()));
@@ -58,12 +58,16 @@ public class StateSpace<S> {
         if (fromIndex < 0 || toIndex < 0) {
             return Optional.empty();
         }
-        return transitionFrom(fromIndex).stream()
+        return transitionFor(fromIndex, toIndex);
+    }
+
+    public Optional<Transition> transitionFor(int fromIndex, int toIndex) {
+        return transitionsFrom(fromIndex).stream()
             .filter(t -> t.toState == toIndex)
             .findFirst();
     }
 
-    public List<Transition> transitionFrom(int stateIndex) {
+    public List<Transition> transitionsFrom(int stateIndex) {
         return Collections.unmodifiableList(fromTransitions.getIfAbsent(stateIndex, FastList::new));
     }
 

--- a/src/main/java/com/allenai/ml/sequences/Transition.java
+++ b/src/main/java/com/allenai/ml/sequences/Transition.java
@@ -9,11 +9,10 @@ import lombok.Value;
  * A transition represents `(from, to)` transition between states. We store the `selfIndex` of the from and to state
  * as well as its index relative to other transitions. This is meant to only be used internal to this package.
  *
- *  __Note__: Default access-level is intentional
  * @See StateSpace
  */
 @AllArgsConstructor
-class Transition {
+public class Transition {
     public final int fromState;
     public final int toState;
     public final int selfIndex;

--- a/src/main/java/com/allenai/ml/sequences/crf/CRFIndexedExample.java
+++ b/src/main/java/com/allenai/ml/sequences/crf/CRFIndexedExample.java
@@ -1,0 +1,143 @@
+package com.allenai.ml.sequences.crf;
+
+import com.allenai.ml.linalg.Vector;
+import com.gs.collections.api.list.primitive.*;
+import com.gs.collections.impl.list.mutable.primitive.DoubleArrayList;
+import com.gs.collections.impl.list.mutable.primitive.IntArrayList;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Memory-efficient representation of the predicates (feature tempaltes) on the node
+ * and edge cliques in the chain CRF model. This class already assumes the data has already
+ * been indexed so the predicates are represented by a `Vector`.
+ *
+ * This class can either represent a training or inference example, depending on whether
+ * `goldLabels` states have been passed in.
+ *
+ * __Internal notes__: Rather than storing a separate `Vector` for each node/edge in the sequence,
+ * we store a long flat integer and double array of all the vectors along with offsets to know the boundaries
+ * for various positions. Since there is about 128 bytes overhead per Vector (class overhead plus some other member
+ * variables), this can be a substantial fraction of the overall memory footprint if you only have a few dozen features.
+ */
+public class CRFIndexedExample {
+
+    // First all the node predicates and then edge predicates
+    private final ImmutableIntList allPredicateIndices;
+    private final ImmutableDoubleList allPredicateValues;
+    private final ImmutableIntList offsets;
+    private final int sequenceLength;
+    private final ImmutableIntList goldLabels;
+
+    public CRFIndexedExample(List<Vector> nodePredicates, List<Vector> edgePredicates, int[] goldLabels) {
+        assert nodePredicates.size() == edgePredicates.size()+1;
+        assert goldLabels == null || goldLabels.length == nodePredicates.size();
+        // Append to indices/values for node/edge predicates separately
+        val allPredicateIndices = new IntArrayList();
+        val allPredicateValues = new DoubleArrayList();
+        val nodeOffsets = flattenPredicates(nodePredicates, allPredicateIndices, allPredicateValues, 0);
+        int numNodePredicates = allPredicateIndices.size();
+        val edgeOffsets = flattenPredicates(edgePredicates, allPredicateIndices, allPredicateValues, numNodePredicates);
+        val offsets = new IntArrayList(nodeOffsets.size() + edgeOffsets.size());
+        offsets.addAll(nodeOffsets);
+        offsets.addAll(edgeOffsets);
+
+        this.sequenceLength = nodePredicates.size();
+        this.offsets = offsets.toImmutable();
+        this.allPredicateIndices = allPredicateIndices.toImmutable();
+        this.allPredicateValues = allPredicateValues.toImmutable();
+        this.goldLabels = goldLabels != null ? new IntArrayList(goldLabels).toImmutable() : null;
+    }
+
+    public CRFIndexedExample(List<Vector> nodePredicates, List<Vector> edgePredicates) {
+        this(nodePredicates, edgePredicates, null);
+    }
+
+    private IntList flattenPredicates(List<Vector> predicateVectors,
+                                      MutableIntList predIndices,
+                                      MutableDoubleList predVals,
+                                      int startOffset) {
+        val offsets = new IntArrayList(predicateVectors.size());
+        int totalOffset = startOffset;
+        for (int idx = 0; idx < predicateVectors.size(); idx++) {
+            offsets.add(totalOffset);
+            List<Vector.Entry> entries = predicateVectors.get(idx)
+                .nonZeroEntries()
+                .collect(Collectors.toList());
+            entries.forEach(e -> {
+                predIndices.addAll((int) e.getIndex());
+                predVals.addAll(e.getValue());
+            });
+            totalOffset += entries.size();
+        }
+        return offsets;
+    }
+
+    public int[] getGoldLabels() {
+        return goldLabels.toArray();
+    }
+
+    public boolean isLabeled() {
+        return goldLabels != null;
+    }
+
+    @RequiredArgsConstructor
+    private class Iterator implements Vector.Iterator {
+        private final int start, stop;
+        private int offset = 0;
+
+        @Override
+        public boolean isExhausted() {
+            return offset >= stop - start;
+        }
+
+        @Override
+        public void advance() {
+            offset++;
+        }
+
+        private void ensureNotExhausted() {
+            if (isExhausted()) {
+                throw new RuntimeException("Iterator is exhausted");
+            }
+        }
+
+        @Override
+        public long index() {
+            ensureNotExhausted();
+            return allPredicateIndices.get(start + offset);
+        }
+
+        @Override
+        public double value() {
+            ensureNotExhausted();
+            return allPredicateValues.get(start + offset);
+        }
+
+        @Override
+        public void reset() {
+            offset = 0;
+        }
+    }
+
+    public Vector.Iterator getNodePredicateValues(int idx) {
+        int start = offsets.get(idx);
+        int stop = offsets.get(idx + 1);
+        return new Iterator(start, stop);
+    }
+
+    public Vector.Iterator getEdgePredicateValues(int idx) {
+        // edge offsets after node ones
+        int start = offsets.get(getSequenceLength() + idx);
+        int stopIdx = getSequenceLength() + idx + 1;
+        int stop =  stopIdx < offsets.size() ? offsets.get(stopIdx) : allPredicateIndices.size();
+        return new Iterator(start, stop);
+    }
+
+    public int getSequenceLength() {
+        return sequenceLength;
+    }
+}

--- a/src/main/java/com/allenai/ml/sequences/crf/CRFWeightsEncoder.java
+++ b/src/main/java/com/allenai/ml/sequences/crf/CRFWeightsEncoder.java
@@ -1,0 +1,87 @@
+package com.allenai.ml.sequences.crf;
+
+import com.allenai.ml.linalg.Vector;
+import com.allenai.ml.sequences.StateSpace;
+import com.allenai.ml.sequences.Transition;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CRFWeightsEncoder<S> {
+    public final StateSpace<S> stateSpace;
+    public final int numNodePredicates;
+    public final int numEdgePredicates;
+
+
+    /**
+     * Parameters for a CRF problem are the number of node predicates needed for each label and for each
+     * state space transition.
+     * @return total number of parameters
+     */
+    public int numParameters() {
+        int numNodeParameters = numNodePredicates * stateSpace.states().size();
+        int numEdgeParameters = numEdgePredicates * stateSpace.transitions().size();
+        return numNodeParameters + numEdgeParameters;
+    }
+
+    // only visible for testing
+    static double[] fillRowPotentials(Vector weights, Vector.Iterator predValueIt, int numValues, int weightOffset) {
+        double[] rowPotentials = new double[numValues];
+        for (int i = 0; i < numValues; i++) {
+            double score = 0.0;
+            while (!predValueIt.isExhausted()) {
+                long predIdx = predValueIt.index();
+                double predVal = predValueIt.value();
+                long weightIdx = predIdx * numValues + i + weightOffset;
+                score +=  weights.at(weightIdx) * predVal;
+                predValueIt.advance();
+            }
+            rowPotentials[i] = score;
+            predValueIt.reset();
+        }
+        return rowPotentials;
+    }
+
+    /**
+     * Produce an array of the scores for the states given the input predicate indices/values. Note this
+     * code tends to be a bottleneck, so written more producedurally than otherwise
+     * @param weights CRF weights
+     * @param predValueIt Iterator over the pred index/values we want to score
+     * @return array in size of `stateSpace.states().size()` of scores
+     */
+    private double[] nodePotentials(Vector weights, Vector.Iterator predValueIt) {
+        int numStates = stateSpace.states().size();
+        return fillRowPotentials(weights, predValueIt, numStates, 0);
+    }
+
+    private double[] edgePotentials(Vector weights, Vector.Iterator predValueIt) {
+        List<Transition> transitions = stateSpace.transitions();
+        int transitionOffset = numNodePredicates;
+        return fillRowPotentials(weights, predValueIt, transitions.size(), transitionOffset);
+    }
+
+    double[][] fillPotentials(Vector weights,  CRFIndexedExample example) {
+        int numTransitions = example.getSequenceLength() - 1;
+        List<Transition> transitions = stateSpace.transitions();
+        double[][] potentials = new double[numTransitions][transitions.size()];
+        for (int i=0; i < numTransitions; ++i) {
+            // The index is in terms of state
+            double[] nodePotentials = nodePotentials(weights, example.getNodePredicateValues(i));
+            double[] edgePotentials = edgePotentials(weights, example.getEdgePredicateValues(i));
+            for (int t = 0; t < transitions.size(); t++) {
+                int s = transitions.get(t).fromState;
+                potentials[i][t] = edgePotentials[t] + nodePotentials[s];
+            }
+        }
+        return potentials;
+    }
+
+    public int nodeWeightIndex(int predIdx, int fromState) {
+        return predIdx * stateSpace.states().size() + fromState;
+    }
+
+    public int edgeWeightIndex(int predIdx, int transitionIdx) {
+        return numNodePredicates + predIdx * stateSpace.transitions().size() + transitionIdx;
+    }
+}

--- a/src/test/java/com/allenai/ml/optimize/NewtonMethodTest.java
+++ b/src/test/java/com/allenai/ml/optimize/NewtonMethodTest.java
@@ -21,6 +21,11 @@ public class NewtonMethodTest {
         testMinimizer(new NewtonMethod(__ -> QuasiNewton.lbfgs(3)));
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroDiffLBFGS() throws Exception {
+        QuasiNewton.lbfgs(1).update(DenseVector.of(10), DenseVector.of(10));
+    }
+
     public void testMinimizer(GradientFnMinimizer minimizer) {
         testExample(minimizer, TestUtils.quartic);
         testExample(minimizer, TestUtils.xSquared);

--- a/src/test/java/com/allenai/ml/sequences/StateSpaceTest.java
+++ b/src/test/java/com/allenai/ml/sequences/StateSpaceTest.java
@@ -29,11 +29,11 @@ public class StateSpaceTest {
         assertEquals(stateSpace.stopState(), STOP);
         assertEquals(new HashSet<>(stateSpace.states()), new HashSet<>(Lists.fixedSize.of(START, STOP, S1, S2, S3)));
         // Test Transitions
-        Set<String> fromStartStates = stateSpace.transitionFrom(stateSpace.stateIndex(START)).stream()
+        Set<String> fromStartStates = stateSpace.transitionsFrom(stateSpace.stateIndex(START)).stream()
                 .map(t -> stateSpace.transition(t.selfIndex).getTwo())
                 .collect(Collectors.toSet());
         assertEquals(fromStartStates, Sets.immutable.of(S1));
-        Set<String> s1Transitions = stateSpace.transitionFrom(stateSpace.stateIndex(S1))
+        Set<String> s1Transitions = stateSpace.transitionsFrom(stateSpace.stateIndex(S1))
                 .stream()
                 .map(t -> stateSpace.transition(t.selfIndex).getTwo())
                 .collect(Collectors.toSet());

--- a/src/test/java/com/allenai/ml/sequences/crf/CRFIndexedExampleTest.java
+++ b/src/test/java/com/allenai/ml/sequences/crf/CRFIndexedExampleTest.java
@@ -1,0 +1,46 @@
+package com.allenai.ml.sequences.crf;
+
+import com.allenai.ml.linalg.SparseVector;
+import com.allenai.ml.linalg.Vector;
+import lombok.val;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.*;
+
+@Test
+public class CRFIndexedExampleTest {
+
+    public void testGoldLabels() {
+        List<Vector> toyNodePreds = CRFTestUtils.toyNodePreds();
+        List<Vector> toyEdgePreds = CRFTestUtils.toyEdgePreds();
+        int[] goldLabels = new int[]{0, 1, 2};
+        val example = new CRFIndexedExample(toyNodePreds, toyEdgePreds, goldLabels);
+        assertTrue(example.isLabeled());
+        assertEquals(example.getGoldLabels(), goldLabels);
+    }
+
+    public void testPredicateCompaction() {
+        List<Vector> toyNodePreds = CRFTestUtils.toyNodePreds();
+        List<Vector> toyEdgePreds = CRFTestUtils.toyEdgePreds();
+        val example = new CRFIndexedExample(toyNodePreds, toyEdgePreds);
+        List<Vector> extractedNodePreds = IntStream.range(0, 3)
+            .mapToObj(idx -> SparseVector.make(10).addInPlace(example.getNodePredicateValues(idx)))
+            .collect(Collectors.toList());
+        List<Vector> extractedEdgePreds = IntStream.range(0, 2)
+            .mapToObj(idx -> SparseVector.make(10).addInPlace(example.getEdgePredicateValues(idx)))
+            .collect(Collectors.toList());
+        assertFalse(example.isLabeled());
+        assertEquals(example.getSequenceLength(), 3);
+        // Verify we can recover the vectors using the iterators for each positon in the node/edges
+        for (int idx = 0; idx < extractedNodePreds.size(); idx++) {
+            assertTrue(extractedNodePreds.get(idx).closeTo(toyNodePreds.get(idx)));
+        }
+        for (int idx = 0; idx < extractedEdgePreds.size(); idx++) {
+            assertTrue(extractedEdgePreds.get(idx).closeTo(toyEdgePreds.get(idx)));
+        }
+    }
+}

--- a/src/test/java/com/allenai/ml/sequences/crf/CRFTestUtils.java
+++ b/src/test/java/com/allenai/ml/sequences/crf/CRFTestUtils.java
@@ -1,0 +1,58 @@
+package com.allenai.ml.sequences.crf;
+
+import com.allenai.ml.linalg.SparseVector;
+import com.allenai.ml.linalg.Vector;
+import com.allenai.ml.sequences.StateSpace;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.factory.Sets;
+import com.gs.collections.impl.tuple.Tuples;
+import lombok.val;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class CRFTestUtils {
+
+    static  Vector vec(Object...args) {
+        val vec = SparseVector.make(10);
+        for (int idx=0; idx < args.length; idx += 2) {
+            vec.set(((Integer)args[idx]).longValue(), (double) args[idx+1]);
+        }
+        return vec;
+    }
+
+    static List<Vector> toyNodePreds() {
+        return Arrays.asList(
+            vec(1, 1.0, 2, 1.0),
+            vec(2, 1.0, 3, 1.0, 4, 1.0),
+            vec(3, 1.0, 4, 1.0));
+    }
+
+    static List<Vector> toyEdgePreds() {
+        return Arrays.asList(
+            vec(3, 1.0, 4, 1.0),
+            vec(2, 1.0, 5, 1.0));
+    }
+
+    static CRFIndexedExample toyExample() {
+        return new CRFIndexedExample(toyNodePreds(), toyEdgePreds());
+    }
+
+    /**
+     * State space for regular expression `a*b*`
+     * @return
+     */
+    static StateSpace<String> toyStateSpace() {
+        val states = Arrays.asList("<s>","</s>", "a", "b");
+        val transitions = Sets.mutable.of(
+            Tuples.pair("<s>", "a"),
+            Tuples.pair("<s>", "b"),
+            Tuples.pair("a", "a"),
+            Tuples.pair("a", "b"),
+            Tuples.pair("a", "</s>"),
+            Tuples.pair("b", "</s>"));
+        return new StateSpace<>(states, transitions);
+    }
+}

--- a/src/test/java/com/allenai/ml/sequences/crf/CRFWeightEncoderTest.java
+++ b/src/test/java/com/allenai/ml/sequences/crf/CRFWeightEncoderTest.java
@@ -1,0 +1,61 @@
+package com.allenai.ml.sequences.crf;
+
+import com.allenai.ml.linalg.DenseVector;
+import com.allenai.ml.linalg.Vector;
+import com.allenai.ml.sequences.ForwardBackwards;
+import com.allenai.ml.sequences.StateSpace;
+import com.allenai.ml.sequences.Transition;
+import lombok.val;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+@Test
+public class CRFWeightEncoderTest {
+
+    public void testRowFiller() throws Exception {
+        // 2 classes, 2 predicates and 2 offset weights
+        Vector weights = DenseVector.of(0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
+        Vector featVec = CRFTestUtils.vec(0, 1.0, 1, 2.0);
+        double[] rowPotentials = CRFWeightsEncoder.fillRowPotentials(weights, featVec.iterator(), 2, 2);
+        // rowPotentials[0] = 1.0 * 1.0 + 3.0 * 2.0 = 7.0
+        // rowPotentials[1] = 1.0 * 3.0 + 2.0 * 4.0 = 10.0
+        assertEquals(rowPotentials, new double[]{7.0, 10.0});
+    }
+
+    public void testEndToEndPotentials() throws Exception {
+        StateSpace<String> stateSpace = CRFTestUtils.toyStateSpace();
+        CRFIndexedExample toyExample = CRFTestUtils.toyExample();
+        val weightEncoder = new CRFWeightsEncoder<String>(stateSpace, 10, 10);
+        double[] weights = new double[weightEncoder.numParameters()];
+        // Test we can spike potnetials for <s> -> a
+        Transition startA = stateSpace.transitionFor("<s>", "a").get();
+        // Spike weights for transitions starting with a
+        for (int predIdx = 0; predIdx < weightEncoder.numEdgePredicates; ++predIdx) {
+            int edgeWeightIndex = weightEncoder.edgeWeightIndex(predIdx, startA.selfIndex);
+            weights[edgeWeightIndex] = 1.0;
+        }
+
+        double[][] potentials = weightEncoder.fillPotentials(DenseVector.of(weights), toyExample);
+        val fbResult = new ForwardBackwards<String>(stateSpace).compute(potentials);
+        List<String> aBiasedViterbi = fbResult.getViterbi();
+        assertEquals(aBiasedViterbi, Arrays.asList("a"));
+
+        Arrays.fill(weights, 0.0);
+        // Test we can spike potnetials for <s> -> a
+        Transition startB = stateSpace.transitionFor("<s>", "b").get();
+        // Spike weights for transitions starting with a
+        for (int predIdx = 0; predIdx < weightEncoder.numEdgePredicates; ++predIdx) {
+            int edgeWeightIndex = weightEncoder.edgeWeightIndex(predIdx, startB.selfIndex);
+            weights[edgeWeightIndex] = 1.0;
+        }
+        potentials = weightEncoder.fillPotentials(DenseVector.of(weights), toyExample);
+        List<String> bBiasedViterbi = new ForwardBackwards<String>(stateSpace)
+            .compute(potentials)
+            .getViterbi();
+        assertEquals(bBiasedViterbi, Arrays.asList("b"));
+    }
+}


### PR DESCRIPTION
This pull does a few related things

* Support for node and edge clique marginals in `ForwardsBackwards`; required for log-likelihood training. CRF++ does Mira based `max` training, but despite being slower, I prefer deterministic log-likelihood training which has some advantages.
* `CRFIndexedExample` class which is a compact memory-efficient representation of the active predicates (feature templates) on the node/edge cliques. From prior experience, you lose a lot in performance if each example has object overhead per clique instead of flattening them out. 
* `CRFWeightEncoder` which knows how to take CRF parameters to populate a potential matrix for use by `ForwardBackwards`

Given the above pieces, I have another PR, I'm trying to keep each around 500-700 lines of diff, which will actually implement the likelihood objective given the above pieces and then I can add a `Main`-class which glues all the pieces together. 

__Testing Coverage__: 
![screen shot 2015-05-12 at 10 28 33 am](https://cloud.githubusercontent.com/assets/31170/7593827/ac000f6a-f891-11e4-9aac-78f1db57af71.png)
