### PR TITLE
Approximate gradient option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ sourceSets {
     }
 }
 
-version = '0.2'
+version = '0.3-SNAPSHOT'
 group = 'org.allenai'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/src/main/java/org/allenai/ml/optimize/ApproximateGradientFn.java
+++ b/src/main/java/org/allenai/ml/optimize/ApproximateGradientFn.java
@@ -1,0 +1,41 @@
+package org.allenai.ml.optimize;
+
+import lombok.RequiredArgsConstructor;
+import org.allenai.ml.linalg.DenseVector;
+import org.allenai.ml.linalg.Vector;
+
+import java.util.function.ToDoubleFunction;
+
+@RequiredArgsConstructor
+public class ApproximateGradientFn implements GradientFn {
+
+    private final long dimension;
+    private final double epsilon;
+    private final ToDoubleFunction<Vector> fn;
+
+    @Override
+    public Result apply(Vector vec) {
+        if (vec.dimension() != dimension) {
+            throw new IllegalArgumentException("Input doesn't agree on dimension");
+        }
+        double fx = fn.applyAsDouble(vec);
+        Vector grad = DenseVector.of(vec.dimension());
+        for (int idx = 0; idx < vec.dimension(); idx++) {
+            vec.inc(idx, epsilon);
+            double fxPlusDelta = fn.applyAsDouble(vec);
+            grad.set(idx, (fxPlusDelta - fx) / epsilon);
+            vec.inc(idx, -epsilon);
+        }
+        return Result.of(fx, grad);
+    }
+
+    @Override
+    public boolean isGradientApproximate() {
+        return true;
+    }
+
+    @Override
+    public long dimension() {
+        return dimension;
+    }
+}

--- a/src/main/java/org/allenai/ml/optimize/BacktrackingLineMinimizer.java
+++ b/src/main/java/org/allenai/ml/optimize/BacktrackingLineMinimizer.java
@@ -21,13 +21,14 @@ public class BacktrackingLineMinimizer implements LineMinimizer {
         if (grad.l2NormSquared() < minStepLen) {
             return Result.of(0.0, f0);
         }
-        final double delta = beta * grad.dotProduct(dir);
+        // Don't be picky about reductions when the gradient is approximate
+        final double delta = gradFn.isGradientApproximate() ? 0.0 :  beta * grad.dotProduct(dir);
         double stepLen = 1.0;
         while (stepLen >= minStepLen) {
             Vector stepX = x.add(stepLen, dir);
             final double fx = gradFn.apply(stepX).fx;
             logger.trace("Step size: alpha {}, new {}, old {}", stepLen, fx, f0);
-            if (fx <= f0 + stepLen * delta) {
+            if (fx < f0 + stepLen * delta) {
                 return Result.of(stepLen, fx);
             }
             stepLen *= alpha;

--- a/src/main/java/org/allenai/ml/optimize/GradientFn.java
+++ b/src/main/java/org/allenai/ml/optimize/GradientFn.java
@@ -43,6 +43,10 @@ public interface GradientFn extends Function<Vector, GradientFn.Result> {
         };
     }
 
+    default boolean isGradientApproximate() {
+        return false;
+    }
+
     static GradientFn from(long dimension, Function<Vector, Result> fn) {
         return new GradientFn() {
             @Override

--- a/src/test/java/org/allenai/ml/optimize/NewtonMethodTest.java
+++ b/src/test/java/org/allenai/ml/optimize/NewtonMethodTest.java
@@ -4,6 +4,8 @@ import org.allenai.ml.linalg.DenseVector;
 import lombok.val;
 import org.testng.annotations.Test;
 
+import java.util.Random;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -26,14 +28,30 @@ public class NewtonMethodTest {
         QuasiNewton.lbfgs(1).update(DenseVector.of(10), DenseVector.of(10));
     }
 
+    @Test
     public void testMinimizer(GradientFnMinimizer minimizer) {
         testExample(minimizer, TestUtils.quartic);
         testExample(minimizer, TestUtils.xSquared);
     }
 
+    private final static Random rand = new Random(0L);
+
+    @Test
     public void testExample(GradientFnMinimizer minimizer, TestUtils.MinExample example) {
-        val res = minimizer.minimize(example.fn, DenseVector.of(example.fn.dimension()));
-        assertTrue(res.xmin.closeTo(example.argMin, 0.1));
+        val initVec = DenseVector.of(example.fn.dimension());
+        for (int idx = 0; idx < initVec.dimension(); idx++) {
+            double x = 2.0 * rand.nextDouble() - 1.0;
+            initVec.set(idx, x);
+        }
+        val res = minimizer.minimize(example.fn, initVec);
+        if (example.argMin != null) {
+            assertTrue(res.xmin.closeTo(example.argMin, 0.1));
+        }
         assertEquals(res.fxmin, example.min, 0.001);
+    }
+
+    @Test
+    public void testApproximate() throws Exception {
+        testExample(new NewtonMethod(__ -> QuasiNewton.lbfgs(3)), TestUtils.approximateCircle);
     }
 }

--- a/src/test/java/org/allenai/ml/optimize/TestUtils.java
+++ b/src/test/java/org/allenai/ml/optimize/TestUtils.java
@@ -31,4 +31,16 @@ public class TestUtils {
         }),
         DenseVector.of(1.0, -2.0),
         0.0);
+
+    public static final MinExample approximateCircle = new MinExample(
+        new ApproximateGradientFn(4, 1.e-10, (Vector x) -> {
+            double x0 = x.at(0);
+            double y0 = x.at(1);
+            double x1 = x.at(2);
+            double y1 = x.at(3);
+            double diff =  Math.sqrt((x0 - x1) * (x0 - x1) + (y0 - y1) * (y0 - y1)) - 3;
+            return diff * diff;
+        }),
+        null,
+        0.0);
 }


### PR DESCRIPTION
Can use approximate gradient via finite differences. The backtracking line search is relaxed for any small decrease since you can't guarantee how much decrease you will get with an approximate gradient.

Added test case matching Euclid's which was failing.