### PR TITLE
Don't insist on sorted strings in the Indexer class ...

### DIFF
--- a/src/main/java/org/allenai/ml/util/Indexer.java
+++ b/src/main/java/org/allenai/ml/util/Indexer.java
@@ -28,9 +28,6 @@ public class Indexer<T extends Comparable<T>> extends AbstractList<T> {
         this.list = elems
             .distinct()
             .collect(Collectors.toList());
-        // Ensure unique representation of indexer
-        // for a set of strings
-        Collections.sort(this.list);
         val m = new ObjectIntHashMap<T>();
         for (int idx = 0; idx < list.size(); idx++) {
             m.put(list.get(idx), idx);

--- a/src/test/java/org/allenai/ml/util/IndexerTest.java
+++ b/src/test/java/org/allenai/ml/util/IndexerTest.java
@@ -23,7 +23,7 @@ public class IndexerTest {
         assertTrue( avengers.contains("cap") );
         assertFalse(avengers.contains("made-up"));
         Object[] arr = avengers.toArray();
-        assertEquals( arr, new String[]{"cap", "hulk", "iron-man"} );
+        assertEquals( arr, new String[]{"cap", "iron-man", "hulk"} );
         assertEquals( avengers, avengers.subList(0, avengers.size()) );
 
     }


### PR DESCRIPTION
... because it corrupts the model when the loaded data isn't sorted already
